### PR TITLE
[Editorial] pith -> pitch

### DIFF
--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -303,7 +303,7 @@
 									<br/>
 									<span>Is sicklied o’er with the pale cast of thought,</span>
 									<br/>
-									<span>And enterprises of great pith and moment</span>
+									<span>And enterprises of great pitch and moment</span>
 									<br/>
 									<span>With this regard their currents turn awry,</span>
 									<br/>


### PR DESCRIPTION
Though `pith` is used in the MIT version, we find `pitch` in the HathiTrust scans.

As I understand it, `pitch` is a term from falconry, meaning **height**, while `moment` encompasses both importance & **momentum**: the image of a falcon ready to pounce and attack; which goes with the "currents turn awry" in the next verse & "lose the name of **action**" after that.

I checked two other sources and they both choose to use `pitch`.
